### PR TITLE
Edit get_review_count_for_product method

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -357,6 +357,7 @@ class WC_Comments {
 			WHERE comment_parent = 0
 			AND comment_post_ID = %d
 			AND comment_approved = '1'
+			AND comment_type = 'review'
 				",
 				$product->get_id()
 			)


### PR DESCRIPTION
### Get review count for product from wp_comments table, where comment type is `review` not all.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

 I created a plugin for rate to products and save data in `wp_comments` table as => comment_type='rating',
so when users rated to products, `get_review_count_for_product` function result is incorrect and result is include all comment_types 

### Changelog entry

> Get review count for product from wp_comments table, where comment type is `review` not all.