### PR TITLE
Edit shortcode_wrapper method

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -56,15 +56,17 @@ class WC_Shortcodes {
 	 *
 	 * @return string
 	 */
-	public static function shortcode_wrapper(
-		$function,
-		$atts = array(),
+	public static function shortcode_wrapper( $function, $atts = array() ) {
+		
 		$wrapper = array(
 			'class'  => 'woocommerce',
 			'before' => null,
 			'after'  => null,
-		)
-	) {
+		);
+		
+		// merge default wrapper with customer attributes
+		$wrapper = wp_parse_args( $atts, $wrapper );
+		
 		ob_start();
 
 		// @codingStandardsIgnoreStart


### PR DESCRIPTION
The shorcode_wrapper method doesn't merge user attributes with default wrapper

### All Submissions:

- [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

1. removing the `$wrapper` argument
2. creating the `$wrapper` variable with default values ( `array('class'  => 'woocommerce','before' => null,'after'  => null)` )
3. merging the `$attr` variable with `$wrapper` variable using `wp_parse_args`

### How to test the changes in this Pull Request:

1. I tested locally and everything worked fine 
2. After changes I can see default css class in woocommerce shortcode wrapper

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> The shorcode_wrapper method doesn't merge user attributes with default wrapper
